### PR TITLE
redis: connect before authenticating

### DIFF
--- a/backend-php/include/wrapper/redis.php
+++ b/backend-php/include/wrapper/redis.php
@@ -8,12 +8,12 @@ class MemWrapper {
 
     function __construct() {
         $this->redis = new Redis();
+        $this->redis->connect(getConfig("redis_host"), getConfig("redis_port"))
+                   or die ("Server could not connect to Redis!\n");
         if (getConfig("redis_use_auth")) {
             $this->redis->auth(getConfig("redis_auth"))
                 or die("Incorrect Redis authentication!");
         }
-        $this->redis->connect(getConfig("redis_host"), getConfig("redis_port"))
-                   or die ("Server could not connect to Redis!\n");
     }
 
     function get($key) {


### PR DESCRIPTION
otherwise we get "Uncaught RedisException: Redis server went away" on Redis->auth()