### PR TITLE
Fix unable to connect to redis socket

### DIFF
--- a/backend-php/include/wrapper/redis.php
+++ b/backend-php/include/wrapper/redis.php
@@ -8,8 +8,13 @@ class MemWrapper {
 
     function __construct() {
         $this->redis = new Redis();
-        $this->redis->connect(getConfig("redis_host"), getConfig("redis_port"))
-                   or die ("Server could not connect to Redis!\n");
+        if(substr(getConfig("redis_host"), 0, 1) === "/") {
+                $this->redis->connect(getConfig("redis_host"))
+                           or die ("Server could not connect to Redis socket!\n");
+        } else {
+                $this->redis->connect(getConfig("redis_host"), getConfig("redis_port"))
+                           or die ("Server could not connect to Redis!\n");
+        }
         if (getConfig("redis_use_auth")) {
             $this->redis->auth(getConfig("redis_auth"))
                 or die("Incorrect Redis authentication!");


### PR DESCRIPTION
If second argument is given, the connection is always parsed as TCP host, since port is defined.

See: https://github.com/phpredis/phpredis/blob/develop/redis.c#L1004