### PR TITLE
Launch the page fullscreen from home screen

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,10 @@
         <!-- The page should not be scalable, since users can just zoom in on
              the map itself directly. -->
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+
+        <!-- Launch the page fullscreen from home screen on iOS and Android -->
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="mobile-web-app-capable" content="yes">
     </head>
     <body>
         <div id="mapouter">


### PR DESCRIPTION
This allows to use "Add to Home screen" button in Chrome to create a shortcut in the launcher that opens Hauk map link like a real app, and not in the browser. Quite useful together with "Preferred link ID", it almost gives the impression of having two activities of Hauk app in my launcher, one (true Hauk app) manages the links and shares, the other one (thanks to this PR) is like an in-app map.

Haven't tested iOS meta tag, I just took it because it was also mentioned in the docs, so I thought why not.

https://developers.google.com/web/fundamentals/native-hardware/fullscreen/#launching_a_page_fullscreen_from_home_screen