### PR TITLE
Fix showing initial active users

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -682,7 +682,6 @@ function processUpdate(data, init) {
 
         // Get the last location received.
         var lastPoint = shares[user].points.length > 0 ? shares[user].points[shares[user].points.length - 1] : null;
-        if (lastPoint !== null) shares[user].listEntry.style.display = "block";
 
         for (var i = 0; i < users[user].length; i++) {
             var lat = users[user][i][0];
@@ -743,6 +742,8 @@ function processUpdate(data, init) {
                 lastPoint = shares[user].points[shares[user].points.length - 1];
             }
         }
+
+        if (lastPoint !== null) shares[user].listEntry.style.display = "block";
 
         var eVelocity = document.getElementById("velocity-" + shares[user].id)
         var vel = 0;


### PR DESCRIPTION
I set refresh interval to 10 minutes. I open the map and see on the map people who were refreshed say 3 minutes ago (which is totally fine), but they don't show up in the active users button until 10 minutes pass. I think this happens because the check for `lastPoint !== null` happens too early, it should happen after the `for` loop where the value possibly can get set.

With this change, the list of active users is correct even when I just open the map.