### PR TITLE
setting accuracy circle also when acc == null 

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -732,8 +732,8 @@ function processUpdate(data, init) {
                 }
                 // Draw an accuracy circle if GPS accuracy was provided by the
                 // client.
-                if (shares[user].circle == null) {
-                    shares[user].circle = L.circle([lat, lon], {radius: acc != null ? acc : 0, fillColor: iconColor, fillOpacity: 0.25, color: iconColor, opacity: 0.5, interactive: false}).addTo(circleLayer);
+                if (acc !== null && shares[user].circle == null) {
+                    shares[user].circle = L.circle([lat, lon], {radius: acc, fillColor: iconColor, fillOpacity: 0.25, color: iconColor, opacity: 0.5, interactive: false}).addTo(circleLayer);
                 } else if (shares[user].circle !== null) {
                     shares[user].circle.setLatLng([lat, lon]);
                     if (acc !== null) shares[user].circle.setRadius(acc);
@@ -856,19 +856,13 @@ function processUpdate(data, init) {
                     }
                     eLastSeen.textContent = unit.split("{{time}}").join(time);
                 }
-                shares[user].circle.setStyle({
-                    fillColor: STATE_DEAD_COLOR,
-                    color: STATE_DEAD_COLOR
-                })
+                setAccuracyCircleColor(shares[user].circle, STATE_DEAD_COLOR);
             } else {
                 eArrow.className = eArrow.className.split("dead").join(shares[user].state);
                 if (eLabel !== null) eLabel.className = shares[user].state;
                 var iconColor = STATE_LIVE_COLOR;
                 if (shares[user].state == "rough") iconColor = STATE_ROUGH_COLOR;
-                shares[user].circle.setStyle({
-                    fillColor: iconColor,
-                    color: iconColor
-                });
+                setAccuracyCircleColor(shares[user].circle, iconColor);
             }
         }
     }
@@ -887,6 +881,15 @@ function processUpdate(data, init) {
         if (!multiUser) {
             following = true;
         }
+    }
+}
+
+function setAccuracyCircleColor(circle, color) {
+    if( circle ) {
+        circle.setStyle({
+            fillColor: color,
+            color: color
+        });
     }
 }
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -885,7 +885,7 @@ function processUpdate(data, init) {
 }
 
 function setAccuracyCircleColor(circle, color) {
-    if( circle ) {
+    if (circle) {
         circle.setStyle({
             fillColor: color,
             color: color

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -732,8 +732,8 @@ function processUpdate(data, init) {
                 }
                 // Draw an accuracy circle if GPS accuracy was provided by the
                 // client.
-                if (acc !== null && shares[user].circle == null) {
-                    shares[user].circle = L.circle([lat, lon], {radius: acc, fillColor: iconColor, fillOpacity: 0.25, color: iconColor, opacity: 0.5, interactive: false}).addTo(circleLayer);
+                if (shares[user].circle == null) {
+                    shares[user].circle = L.circle([lat, lon], {radius: acc != null ? acc : 0, fillColor: iconColor, fillOpacity: 0.25, color: iconColor, opacity: 0.5, interactive: false}).addTo(circleLayer);
                 } else if (shares[user].circle !== null) {
                     shares[user].circle.setLatLng([lat, lon]);
                     if (acc !== null) shares[user].circle.setRadius(acc);


### PR DESCRIPTION
This fix makes sure that an accuracy circle with radius 0 is instantiated even if `acc == null`, otherwise the missing circle leads to a "Session expired" error further down the line. Although a radius of 0 implies "perfect accuracy", I think other solutions, be it a fixed width circle or a custom icon, are more distracting than helpful. Fixes #165