### PR TITLE
Fix incorrectly reporting LDAP errors when cannot find HTPASSWD file

### DIFF
--- a/backend-php/include/inc.php
+++ b/backend-php/include/inc.php
@@ -807,18 +807,18 @@ function authenticated() {
             global $LANG;
             if (!isset($_POST["usr"])) die($LANG["username_required"]);
             requirePOST("pwd", "usr");
-			// Jump out if we cannot find the htpasswd file.
-			if (!file_exists(getConfig("htpasswd_path"))) die($LANG["cannot_find_password_file"]);
-			$file = fopen(getConfig("htpasswd_path"), "r");
-			$authed = false;
-			while (($line = fgets($file)) !== false && !$authed) {
-				$creds = explode(":", trim($line));
-				if ($creds[0] == $_POST["usr"]) {
-					$authed = password_verify($_POST["pwd"], $creds[1]);
-				}
-			}
-			fclose($file);
-			return $authed;
+            // Jump out if we cannot find the htpasswd file.
+            if (!file_exists(getConfig("htpasswd_path"))) die($LANG["cannot_find_password_file"]);
+            $file = fopen(getConfig("htpasswd_path"), "r");
+            $authed = false;
+            while (($line = fgets($file)) !== false && !$authed) {
+                $creds = explode(":", trim($line));
+                if ($creds[0] == $_POST["usr"]) {
+                    $authed = password_verify($_POST["pwd"], $creds[1]);
+                }
+            }
+            fclose($file);
+            return $authed;
 
         case LDAP:
             // LDAP-based authentication.

--- a/backend-php/include/inc.php
+++ b/backend-php/include/inc.php
@@ -807,18 +807,18 @@ function authenticated() {
             global $LANG;
             if (!isset($_POST["usr"])) die($LANG["username_required"]);
             requirePOST("pwd", "usr");
-            if (file_exists(getConfig("htpasswd_path"))) {
-                $file = fopen(getConfig("htpasswd_path"), "r");
-                $authed = false;
-                while (($line = fgets($file)) !== false && !$authed) {
-                    $creds = explode(":", trim($line));
-                    if ($creds[0] == $_POST["usr"]) {
-                        $authed = password_verify($_POST["pwd"], $creds[1]);
-                    }
-                }
-                fclose($file);
-                return $authed;
-            }
+			// Jump out if we cannot find the htpasswd file.
+			if (!file_exists(getConfig("htpasswd_path"))) die($LANG["cannot_find_htpasswd_file"]);
+			$file = fopen(getConfig("htpasswd_path"), "r");
+			$authed = false;
+			while (($line = fgets($file)) !== false && !$authed) {
+				$creds = explode(":", trim($line));
+				if ($creds[0] == $_POST["usr"]) {
+					$authed = password_verify($_POST["pwd"], $creds[1]);
+				}
+			}
+			fclose($file);
+			return $authed;
 
         case LDAP:
             // LDAP-based authentication.

--- a/backend-php/include/inc.php
+++ b/backend-php/include/inc.php
@@ -808,7 +808,7 @@ function authenticated() {
             if (!isset($_POST["usr"])) die($LANG["username_required"]);
             requirePOST("pwd", "usr");
 			// Jump out if we cannot find the htpasswd file.
-			if (!file_exists(getConfig("htpasswd_path"))) die($LANG["cannot_find_htpasswd_file"]);
+			if (!file_exists(getConfig("htpasswd_path"))) die($LANG["cannot_find_password_file"]);
 			$file = fopen(getConfig("htpasswd_path"), "r");
 			$authed = false;
 			while (($line = fgets($file)) !== false && !$authed) {

--- a/backend-php/include/lang/ca/texts.php
+++ b/backend-php/include/lang/ca/texts.php
@@ -18,3 +18,4 @@ $LANG['invalid_storage'] = 'Heu establert un storage_backend d\'emmagatzematge n
 $LANG['no_redis_ext'] = 'No hi ha habilitada cap extensió redis compatible (redis) a la vostra configuració PHP!';
 $LANG['no_memcached_ext'] = 'No hi ha habilitada cap extensió confidencial (memcache o memcached) a la configuració de PHP!';
 $LANG['config_missing'] = 'No es pot trobar config.php!';
+$LANG['cannot_find_password_file'] = 'No es troba el fitxer de contrasenya!';

--- a/backend-php/include/lang/de/texts.php
+++ b/backend-php/include/lang/de/texts.php
@@ -24,3 +24,4 @@ $LANG['ldap_search_failed'] = 'Benutzer konnte am LDAP Server nicht gefunden wer
 $LANG['ldap_connection_failed'] = 'Fehler beim Verbinden zum LDAP Server!';
 $LANG['ldap_config_error'] = 'LDAP-Verbindungsparameter konnten nicht eingestellt werden!';
 $LANG['ldap_extension_missing'] = 'Die LDAP Erweiterung ist in der PHP config nicht aktiviert!';
+$LANG['cannot_find_password_file'] = 'Kennwortdatei kann nicht gefunden werden!';

--- a/backend-php/include/lang/en/texts.php
+++ b/backend-php/include/lang/en/texts.php
@@ -24,3 +24,4 @@ $LANG['ldap_connection_failed'] = 'Failed to connect to the LDAP server!';
 $LANG['ldap_search_failed'] = 'Failed to look up user on the LDAP server!';
 $LANG['ldap_user_unauthorized'] = 'User not found, not authorized, or incorrect password!';
 $LANG['ldap_search_ambiguous'] = 'Matched multiple users - the LDAP filter is too broad!';
+$LANG['cannot_find_password_file'] = 'Cannot find password file!';

--- a/backend-php/include/lang/eu/texts.php
+++ b/backend-php/include/lang/eu/texts.php
@@ -15,3 +15,4 @@ $LANG['share_mode_unsupported'] = 'Euskarririk gabeko parekatze modua!';
 $LANG['group_pin_invalid'] = 'Baliogabeko talde PIN-a!';
 $LANG['session_invalid'] = 'Saio baliogabea!';
 $LANG['location_invalid'] = 'Kokaleku baliogabea!';
+$LANG['cannot_find_password_file'] = 'Ezin da pasahitz fitxategia aurkitu!';

--- a/backend-php/include/lang/fr/texts.php
+++ b/backend-php/include/lang/fr/texts.php
@@ -24,3 +24,4 @@ $LANG['ldap_extension_missing'] = 'L\'extension LDAP n\'est pas activée dans vo
 $LANG['e2e_adoption_not_allowed'] = 'Ce partage est protégé par un mot de passe et ne peut pas être adopté !';
 $LANG['group_e2e_unsupported'] = 'Les partages de groupe ne peuvent pas être protégés par un mot de passe !';
 $LANG['username_required'] = 'Nom d\'utilisateur requis !';
+$LANG['cannot_find_password_file'] = 'Impossible de trouver le fichier de mot de passe !';

--- a/backend-php/include/lang/it/texts.php
+++ b/backend-php/include/lang/it/texts.php
@@ -24,3 +24,4 @@ $LANG['invalid_storage'] = 'storage_backend non è impostata correttamente in Ha
 $LANG['no_redis_ext'] = 'Nessuna estensione compatibile con redi (redi) è attiva nella tua configurazione PHP!';
 $LANG['no_memcached_ext'] = 'Nessuna estensione compatibile con memcached (memecache o memecached) è attiva nella tua configurazione PHP!';
 $LANG['config_missing'] = 'Impossibile trovare config.php!';
+$LANG['cannot_find_password_file'] = 'Impossibile trovare il file della password!';

--- a/backend-php/include/lang/nl/texts.php
+++ b/backend-php/include/lang/nl/texts.php
@@ -24,3 +24,4 @@ $LANG['ldap_search_failed'] = 'Fout tijdens het opzoeken van de gebruiker op de 
 $LANG['ldap_connection_failed'] = 'Kan geen verbinding maken met de LDAP server!';
 $LANG['ldap_config_error'] = 'Niet gelukt om LDAP connectieparameters in te stellen!';
 $LANG['ldap_extension_missing'] = 'De LDAP extensie is niet actief in uw PHP configuratie!';
+$LANG['cannot_find_password_file'] = 'Kan geen wachtwoordbestand vinden!';

--- a/backend-php/include/lang/nn/texts.php
+++ b/backend-php/include/lang/nn/texts.php
@@ -24,3 +24,4 @@ $LANG['ldap_search_failed'] = 'Kunne ikkje slå opp brukaren på LDAP-serveren!'
 $LANG['ldap_connection_failed'] = 'Kunne ikkje kopla til LDAP-serveren!';
 $LANG['ldap_config_error'] = 'Kunne ikkje setja LDAP-tilkoplingsparametrar!';
 $LANG['ldap_extension_missing'] = 'ldap-utvidinga er ikkje aktivert i PHP-konfigurasjonen din!';
+$LANG['cannot_find_password_file'] = 'Kan ikke finne passordfil!';

--- a/backend-php/include/lang/pl/texts.php
+++ b/backend-php/include/lang/pl/texts.php
@@ -24,3 +24,4 @@ $LANG['share_not_found'] = 'Ta sesja nie istnieje!';
 $LANG['session_expired'] = 'Sesja wygasła!';
 $LANG['invalid_storage'] = 'Ustawiłeś niepoprawny storage_backend w Hauk!';
 $LANG['config_missing'] = 'Nie można odnaleźć pliku config.php!';
+$LANG['cannot_find_password_file'] = 'Nie można znaleźć pliku hasła!';

--- a/backend-php/include/lang/ro/texts.php
+++ b/backend-php/include/lang/ro/texts.php
@@ -24,3 +24,4 @@ $LANG['ldap_search_failed'] = 'Nu s-a putut găsi utilizatorul pe serverul LDAP!
 $LANG['ldap_connection_failed'] = 'Nu s-a putut face conexiunea cu serverul LDAP!';
 $LANG['ldap_config_error'] = 'Nu s-au putut seta parametrii conexiunii LDAP!';
 $LANG['ldap_extension_missing'] = 'Extensia ldap nu este activată în configurația PHP!';
+$LANG['cannot_find_password_file'] = 'Nu pot găsi fișierul de parolă!';

--- a/backend-php/include/lang/ru/texts.php
+++ b/backend-php/include/lang/ru/texts.php
@@ -15,3 +15,4 @@ $LANG['invalid_storage'] = 'У вас неверный storage_backend для Ha
 $LANG['no_redis_ext'] = 'Нет включенных совместимых расширений redis в вашей конфигурации PHP!';
 $LANG['no_memcached_ext'] = 'Нет включенных совместимых расширений в вашей конфигурации PHP (memcache or memcached)!';
 $LANG['config_missing'] = 'Не могу найти config.php!';
+$LANG['cannot_find_password_file'] = 'Не удается найти файл пароля';

--- a/backend-php/include/lang/tr/texts.php
+++ b/backend-php/include/lang/tr/texts.php
@@ -24,3 +24,4 @@ $LANG['username_required'] = 'Kullanıcı adı gerekli!';
 $LANG['incorrect_password'] = 'Hatalı parola!';
 $LANG['session_expired'] = 'Oturum süresi doldu!';
 $LANG['config_missing'] = 'config.php bulunamıyor!';
+$LANG['cannot_find_password_file'] = 'Şifre dosyasını bulamıyor';

--- a/backend-php/include/lang/uk/texts.php
+++ b/backend-php/include/lang/uk/texts.php
@@ -15,3 +15,4 @@ $LANG['group_pin_invalid'] = 'Невірний груповий PIN!';
 $LANG['session_invalid'] = 'Недійсний сеанс!';
 $LANG['location_invalid'] = 'Недійсне місцезнаходження!';
 $LANG['config_missing'] = 'Не можу знайти config.php!';
+$LANG['cannot_find_password_file'] = 'Не вдається знайти файл пароля';


### PR DESCRIPTION
Fixes a bug where the authenticated method drops through from the HTPASSWD case to the LDAP case when no htpasswd file is found.

This was mentioned in 2020 in issue [#142](https://github.com/bilde2910/Hauk/issues/142) but was subsequently closed when the reporter reinstalled their system and no longer could see the issue.

I have also added translations for the new error. These were done through google translate, so I cannot guarantee the quality. I have added these in a separate commit in case you wish to not include them.