### PR TITLE
Add LDAP certificate checking strategy option to config

### DIFF
--- a/backend-php/include/config-sample.php
+++ b/backend-php/include/config-sample.php
@@ -109,6 +109,14 @@
 // combination with `ldaps`.
 "ldap_start_tls"    => false,
 
+// Specifies the certificate checking strategy. This must be one of:
+// LDAP_OPT_X_TLS_NEVER
+// LDAP_OPT_X_TLS_HARD
+// LDAP_OPT_X_TLS_DEMAND
+// LDAP_OPT_X_TLS_ALLOW
+// LDAP_OPT_X_TLS_TRY
+"ldap_require_cert" => 'LDAP_OPT_X_TLS_ALLOW',
+
 // Base DN to search for users.
 "ldap_base_dn"      => 'ou=People,dc=example,dc=com',
 

--- a/backend-php/include/inc.php
+++ b/backend-php/include/inc.php
@@ -127,6 +127,7 @@ const DEFAULTS = array(
     "password_hash"         => '$2y$10$4ZP1iY8A3dZygXoPgsXYV.S3gHzBbiT9nSfONjhWrvMxVPkcFq1Ka',
     "htpasswd_path"         => '/etc/hauk/users.htpasswd',
     "ldap_uri"              => 'ldaps://ldap.example.com:636',
+    "ldap_tls_require_cert" => 'LDAP_OPT_X_TLS_DEMAND',
     "ldap_start_tls"        => false,
     "ldap_base_dn"          => 'ou=People,dc=example,dc=com',
     "ldap_bind_dn"          => 'cn=admin,dc=example,dc=com',
@@ -829,6 +830,7 @@ function authenticated() {
             if (strlen($_POST["pwd"]) == 0) die($LANG["incorrect_password"]);
 
             // Connect to the LDAP server.
+            ldap_set_option(null, LDAP_OPT_X_TLS_REQUIRE_CERT, getConfig("ldap_tls_require_cert"));
             $ldc = @ldap_connect(getConfig("ldap_uri"));
             if ($ldc === false) die($LANG["ldap_config_error"]);
             ldap_set_option($ldc, LDAP_OPT_PROTOCOL_VERSION, 3);


### PR DESCRIPTION
Hey, first of all thanks for this great and lightweight tool.
I made a small addition that exposes the LDAP certificate checking strategy to the user config (`ldap_require_cert` option). This allows users to e.g. use LDAPS without fiddling around with self-signed certificates.